### PR TITLE
Expose metadata endpoint

### DIFF
--- a/_lambda/metadata.js
+++ b/_lambda/metadata.js
@@ -1,0 +1,10 @@
+import members from '../src/data/members';
+
+exports.handler = (event, context, callback) => {
+  return callback(null, {
+    statusCode: 200,
+    body: JSON.stringify({
+      members
+    })
+  })
+}

--- a/netlify.toml
+++ b/netlify.toml
@@ -28,3 +28,8 @@
     to = "/.netlify/functions/random"
     status = 301
     force = true
+
+[[redirects]]
+    from = "/metadata"
+    to = "/.netlify/functions/metadata"
+    status = 200


### PR DESCRIPTION
I wanted a way to display the number of members in the ring without using the component, and adding a metadata endpoint seemed like one way to go! It currently returns the full members list:
```
[webring] mac% curl -s -X GET http://127.0.0.1:9000/metadata | jq
{
  "members": [
    {
      "title": "chemecse.io",
      "url": "https://chemecse.io"
    },
    {
      "title": "vipyne",
      "url": "https://vipyne.github.io"
    },
    {
      "title": "bleveque",
      "url": "https://bleveque.github.io"
    },
    {
      "title": "sam brenner",
      "url": "https://samjbrenner.com"
    }
  ]
}
```